### PR TITLE
Add `id` to trip summaries returned by tripgo-routing tool.

### DIFF
--- a/src/tools/tripgo.ts
+++ b/src/tools/tripgo.ts
@@ -122,6 +122,7 @@ interface TripGroup {
 }
 
 interface Trip {
+  id: string;
   arrive: number;
   depart: number;
   moneyCost?: number;
@@ -397,6 +398,7 @@ async function handleRouting(
         });
 
         return {
+          id: trip.id,
           depart: toISOStringInTimezone(new Date(trip.depart * 1000), timezone),          
           arrive: toISOStringInTimezone(new Date(trip.arrive * 1000), timezone),
           totalDuration: Math.floor((trip.arrive - trip.depart) / 60),


### PR DESCRIPTION
@nighthawk I need to add the `id` to the trip results so Claude can then map them to human readable references by using the new `tripgo-ui-reference-trips` tool.

Can you please also do a deploy?