### PR TITLE
Remove indentation of tripgo-routing result JSON to reduce token usage.

### DIFF
--- a/src/tools/tripgo.ts
+++ b/src/tools/tripgo.ts
@@ -439,13 +439,10 @@ async function handleRouting(
         to: {
           lat: toLat,
           lng: toLng,
-        },
-        url: url.toString(),
-      },
-    },
-    null,
-    2,
-  );
+        },        
+        url: url.toString()
+      }
+    });
 }
 
 interface SaveTripResponse extends TripGoResponse {
@@ -792,8 +789,7 @@ const tripgoRoutingTool = {
         params.limit,
       );
       return {
-        content: [{ type: "text" as const, text: String(result) }],
-        structuredContent: JSON.parse(result),
+        content: [{ type: "text" as const, text: String(result) }]
       };
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
@nighthawk as part of [#24426](https://redmine.buzzhives.com/issues/24426) (TripGo AI Assistant: track and optimize Anthropic API token usage) I removed the indentation on tripgo-routing tool output to save some token usage. Claude interpreats the JSON correctly without the indentation.

Also removed the `structuredContent` field, which contained the same JSON, but as an object. I think it wasn't impacting in the token usage, just in case. We can re-add it if you use it for something.
